### PR TITLE
remove nostamp from kernel-initramfs' do_install task

### DIFF
--- a/meta-efi-secure-boot/recipes-kernel/linux/kernel-initramfs-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-kernel/linux/kernel-initramfs-efi-secure-boot.inc
@@ -1,7 +1,7 @@
 inherit user-key-store deploy
 
 # Always fetch the latest initramfs image
-do_install[nostamp] = "1"
+#do_install[nostamp] = "1"
 
 fakeroot python do_sign() {
     initramfs = None


### PR DESCRIPTION
Sometimes initramfs image is actually not changed during rebuild,
on this scenario, kernel-initramfs package should not be done again.

This will reduce the download bandwidth during system upgrade, if
there is no change to initramfs image. And it means a lot to IOT
devices.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>